### PR TITLE
Disable JWT when query param is missing, add auth for some other functions

### DIFF
--- a/modules/engage-paella-player-7/src/index.js
+++ b/modules/engage-paella-player-7/src/index.js
@@ -61,47 +61,51 @@ window.onload = async () => {
 // as far as I can tell. This query parameter passing method is known and used.
 // Also, the SW is super tiny, so the additional fetches don't really matter.
 const params = new URLSearchParams(window.location.search);
-let refreshEnabled = params.get('jwtRefresh') === 'true';
-if (refreshEnabled && window.self === window.top) {
-  // eslint-disable-next-line no-console
-  console.warn('jwtRefresh=true given, but not running in iframe');
-  refreshEnabled = false;
-}
-const swUrl = `sw.js?${new URLSearchParams({
-  jwt: params.get('jwt'),
-  videoId: params.get('id'),
-  refresh: refreshEnabled,
-})}`;
+const jwt = params.get('jwt');
 
-navigator.serviceWorker
-  .register(swUrl, { updateViaCache: 'none' })
-  // eslint-disable-next-line no-console
-  .catch(e => console.error('Failed to register service worker', e));
+if (jwt) {
+  let refreshEnabled = params.get('jwtRefresh') === 'true';
+  if (refreshEnabled && window.self === window.top) {
+    // eslint-disable-next-line no-console
+    console.warn('jwtRefresh=true given, but not running in iframe');
+    refreshEnabled = false;
+  }
+  const swUrl = `sw.js?${new URLSearchParams({
+    jwt,
+    videoId: params.get('id'),
+    refresh: refreshEnabled,
+  })}`;
+
+  navigator.serviceWorker
+    .register(swUrl, { updateViaCache: 'none' })
+    // eslint-disable-next-line no-console
+    .catch(e => console.error('Failed to register service worker', e));
 
 
 
-// If JWT refresh is enabled, we need to forward messages between the host of
-// this iframe and the SW (as they cannot communicate directly).
-if (refreshEnabled) {
-  // Forward messages coming from the iframe host to the SW.
-  window.addEventListener('message', ev => {
-    if (ev.source !== window.parent) {
-      return;
-    }
+  // If JWT refresh is enabled, we need to forward messages between the host of
+  // this iframe and the SW (as they cannot communicate directly).
+  if (refreshEnabled) {
+    // Forward messages coming from the iframe host to the SW.
+    window.addEventListener('message', ev => {
+      if (ev.source !== window.parent) {
+        return;
+      }
 
-    const d = ev.data;
-    if (typeof d === 'object' && d?.type === 'oc-event-jwt' && typeof d?.jwt === 'string') {
-      const { type, jwt } = d;
-      navigator.serviceWorker.controller?.postMessage({ type, jwt });
-    }
-  });
+      const d = ev.data;
+      if (typeof d === 'object' && d?.type === 'oc-event-jwt' && typeof d?.jwt === 'string') {
+        const { type, jwt } = d;
+        navigator.serviceWorker.controller?.postMessage({ type, jwt });
+      }
+    });
 
-  // Forward messages coming from the SW to the iframe host.
-  navigator.serviceWorker.addEventListener('message', ev => {
-    const d = ev.data;
-    if (typeof d === 'object' && d?.type === 'oc-event-jwt-request' && typeof d?.event === 'string') {
-      const { type, event } = d;
-      window.parent.postMessage({ type, event }, '*');
-    }
-  });
+    // Forward messages coming from the SW to the iframe host.
+    navigator.serviceWorker.addEventListener('message', ev => {
+      const d = ev.data;
+      if (typeof d === 'object' && d?.type === 'oc-event-jwt-request' && typeof d?.event === 'string') {
+        const { type, event } = d;
+        window.parent.postMessage({ type, event }, '*');
+      }
+    });
+  }
 }

--- a/modules/engage-paella-player-7/src/js/OpencastAuth.js
+++ b/modules/engage-paella-player-7/src/js/OpencastAuth.js
@@ -19,7 +19,7 @@
  *
  */
 
-import { getUrlFromOpencastServer } from './PaellaOpencast';
+import { getJwtParam, getUrlFromOpencastServer } from './PaellaOpencast';
 
 export default class OpencastAuth {
   constructor(player) {
@@ -41,7 +41,9 @@ export default class OpencastAuth {
 
   async getEpisodeACL() {
     try {
-      const response = await fetch(getUrlFromOpencastServer(`/search/episode.json?id=${this.player.videoId}`));
+      const response = await fetch(
+        getUrlFromOpencastServer(`/search/episode.json?id=${this.player.videoId}${getJwtParam()}`)
+      );
       if (response.ok) {
         const episode = await response.json();
         return episode['result'][0]?.acl;

--- a/modules/engage-paella-player-7/src/js/PaellaOpencast.js
+++ b/modules/engage-paella-player-7/src/js/PaellaOpencast.js
@@ -23,7 +23,7 @@
 /* global OPENCAST_CONFIG_URL */
 /* global OPENCAST_PAELLA_URL */
 
-import { Paella, bindEvent, Events, utils, log } from 'paella-core';
+import { bindEvent, Events, log, Paella, utils } from 'paella-core';
 import getBasicPluginContext from 'paella-basic-plugins';
 import getSlidePluginContext from 'paella-slide-plugins';
 import getZoomPluginContext from 'paella-zoom-plugin';
@@ -50,6 +50,15 @@ function getUrlFromBase(base, url) {
 
   const fullURL = `${a}/${b}`;
   return fullURL;
+}
+
+/**
+ * Returns the JWT query parameter string (e.g. '&jwt=...') if a JWT is present
+ * in the page URL, or an empty string otherwise.
+ */
+export function getJwtParam() {
+  const jwt = new URLSearchParams(location.search).get('jwt');
+  return jwt ? `&jwt=${jwt}` : '';
 }
 
 export function getUrlFromOpencastServer(url) {
@@ -105,12 +114,7 @@ const initParams = {
   repositoryUrl: getUrlFromOpencastServer('/search/episode.json'),
 
   getManifestUrl: (repoUrl, videoId) => {
-    let out =  `${repoUrl}?id=${videoId}`;
-    const jwt = new URLSearchParams(location.search).get('jwt');
-    if (jwt) {
-      out += `&jwt=${jwt}`;
-    }
-    return out;
+    return `${repoUrl}?id=${videoId}${getJwtParam()}`;
   },
 
   getManifestFileUrl: (manifestUrl) => {
@@ -338,10 +342,10 @@ export class PaellaOpencast extends Paella {
   }
 
   async getEpisode({episodeId}) {
-    return fetch(getUrlFromOpencastServer(`/search/episode.json?id=${episodeId}`))
-    .then(response => response.json() )
-    .then(response => response['result'][0])
-    .catch(() => null);
+    return fetch(getUrlFromOpencastServer(`/search/episode.json?id=${episodeId}${getJwtParam()}`))
+      .then(response => response.json() )
+      .then(response => response['result'][0])
+      .catch(() => null);
   }
 
   get opencastAuth() {


### PR DESCRIPTION
Simply puts an `if` guard around the JWT/service worker specific code and adds optional checks:
- to `getEpisode`, which is used in the download plugin, and
- to `getEpisodeACL`, which is used in write checks.

Note that these are probably redundant, as by the time these checks are run, the current session is likely already authenticated. I am not completely sure what happens if the JWT is already expired by then. If you think or know that can be problematic, maybe it's better to omit the second commit.